### PR TITLE
chore: update GitHub Actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies
@@ -41,12 +41,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies
@@ -62,7 +62,7 @@ jobs:
 
       - name: Configure AWS credentials
         if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/v3-rewrite')
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v5
         with:
           role-to-assume: ${{ vars.IAM_ROLE }}
           aws-region: us-east-1

--- a/.github/workflows/fetch-pricing.yml
+++ b/.github/workflows/fetch-pricing.yml
@@ -17,12 +17,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v5
         with:
           role-to-assume: ${{ vars.IAM_ROLE }}
           aws-region: us-east-1

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -17,12 +17,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies
@@ -34,7 +34,7 @@ jobs:
         run: npm run build
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v5
         with:
           role-to-assume: ${{ vars.IAM_ROLE }}
           aws-region: us-east-1
@@ -43,7 +43,7 @@ jobs:
         run: aws s3 sync ./dist s3://gcpinstances.doit.com/previews/pr-${{ github.event.pull_request.number }}/
 
       - name: Comment preview URL
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const url = `https://gcpinstances.doit.com/previews/pr-${{ github.event.pull_request.number }}/`


### PR DESCRIPTION
## Summary

- Bump `actions/checkout` v4 → **v5** (node24 runtime)
- Bump `actions/setup-node` v4 → **v5** (node24 runtime)
- Bump `aws-actions/configure-aws-credentials` v4 → **v5** (node24 runtime)
- Bump `actions/github-script` v7 → **v8** (node24 runtime)
- Update `node-version: '20'` → `'22'` (Node 22 LTS) in all 3 workflows

## Why

GitHub Actions is deprecating Node.js 20 for action runtimes:
- **June 2, 2026**: Actions forced to Node.js 24 by default
- **September 16, 2026**: Node.js 20 removed from runners entirely

All 4 workflows were emitting deprecation warnings. This brings all actions and the app runtime forward before the deadline.

## Files changed

- `.github/workflows/ci.yml`
- `.github/workflows/fetch-pricing.yml`
- `.github/workflows/preview.yml`
- `.github/workflows/preview-cleanup.yml`

## Test plan
- [x] No `@v4` / `@v7` / `node-version: '20'` references remain in `.github/workflows/`
- [ ] CI passes on this PR with the updated action versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)