### PR TITLE
fix: source CoreMark scores from live localized docs, add n4-highcpu-80

### DIFF
--- a/DATA_PIPELINE.md
+++ b/DATA_PIPELINE.md
@@ -28,16 +28,29 @@ React frontend                     (client-side filtering, sorting, display)
 
 ### CoreMark scores
 
-CoreMark scores are **not** fetched from an API. Google used to publish them at
-[CoreMark scores of VM instances by family](https://cloud.google.com/compute/docs/coremark-scores-of-vm-instances),
-but retired the score tables from that page in early 2026 — it now only documents how to run
-PerfKitBenchmarker yourself and directs you to your account team to ask about scores.
+CoreMark scores are **not** fetched from an API — they live in `COREMARK_SCORES` in
+`scripts/machine-types.ts`.
 
-The values in `COREMARK_SCORES` are therefore a frozen copy of the last published revision
-and cannot be refreshed automatically. Machine types released after that revision (C4, A3,
-the newer A2 GPU shapes) have no published score and render as `N/A`. To add scores for
-those, benchmark them with PerfKitBenchmarker or get numbers from a Google account team,
-then add the entries to `COREMARK_SCORES`.
+Google retired the score tables from the **English** page in early 2026; it now only
+documents how to run PerfKitBenchmarker yourself. But three localized versions still serve
+the full tables and are the live source for this data:
+
+- [`?hl=ko`](https://cloud.google.com/compute/docs/coremark-scores-of-vm-instances?hl=ko) (Korean)
+- [`?hl=ja`](https://cloud.google.com/compute/docs/coremark-scores-of-vm-instances?hl=ja) (Japanese)
+- [`?hl=zh-cn`](https://cloud.google.com/compute/docs/coremark-scores-of-vm-instances?hl=zh-cn) (Simplified Chinese)
+
+Dropping the `?hl=` parameter gives you the English page, which no longer has the data. All
+other locales tested (de, fr, es, it, pt-br, ru, zh-tw, and others) have also had the tables
+removed.
+
+All three were cross-checked against each other and against the last English revision:
+**228 machine types, zero disagreements on any value.**
+
+These pages could be trimmed to match English at any time, so treat `COREMARK_SCORES` as
+the source of truth rather than assuming a refresh is always possible. Machine types
+released after the last benchmark run (C4, A3, the newer A2 GPU shapes, shared-core E2)
+have no published score and render as `N/A`; to fill those in, benchmark with
+PerfKitBenchmarker or get numbers from a Google account team.
 
 ## API Key Setup
 

--- a/public/data/pricing.json
+++ b/public/data/pricing.json
@@ -90987,7 +90987,7 @@
       "gpuType": null,
       "soleTenantSupport": true,
       "nestedVirtualizationSupport": true,
-      "coremarkScore": null,
+      "coremarkScore": 1651766,
       "pricing": {
         "us-west8": {
           "linuxOnDemand": 2.7784,

--- a/scripts/machine-types.ts
+++ b/scripts/machine-types.ts
@@ -710,5 +710,6 @@ export const COREMARK_SCORES: Record<string, number> = {
 
   // N1 shared-core VMs — Skylake
   'f1-micro': 3949,
-  'g1-small': 10191,}
+  'g1-small': 10191,
+}
 

--- a/scripts/machine-types.ts
+++ b/scripts/machine-types.ts
@@ -384,7 +384,7 @@ export const MACHINE_TYPE_MAP = new Map(MACHINE_TYPES.map((m) => [m.name, m]))
  * Linux CoreMark benchmark scores, keyed by machine type name.
  *
  * Source: Google Cloud, "CoreMark scores of VM instances by family"
- *   https://cloud.google.com/compute/docs/coremark-scores-of-vm-instances
+ *   https://cloud.google.com/compute/docs/coremark-scores-of-vm-instances?hl=ko
  *
  * Each score is the aggregate multi-threaded CoreMark result measured by Google
  * with PerfKitBenchmarker on ubuntu2204, running threads equal to the machine
@@ -392,13 +392,22 @@ export const MACHINE_TYPE_MAP = new Map(MACHINE_TYPES.map((m) => [m.name, m]))
  * throughput, not per-core performance. The CPU platform noted per group is the
  * one Google benchmarked on; the same machine type can land on a newer platform.
  *
- * IMPORTANT: Google retired these tables from the page above in early 2026 — it
- * now only documents how to run PerfKitBenchmarker yourself and directs you to
- * your account team to ask about scores. The values below are frozen from the
- * last published revision (verified identical in the 2025-11-04 and 2025-12-05
- * Internet Archive snapshots) and cannot be refreshed from a public Google
- * source. Machine types released after that revision (C4, A3, the newer A2 GPU
- * shapes) have no published score and are intentionally absent.
+ * IMPORTANT: Google retired these tables from the ENGLISH page in early 2026 —
+ * it now only documents how to run PerfKitBenchmarker yourself and directs you
+ * to your account team to ask about scores. Three localized versions still
+ * serve the full tables and are the live source for this data:
+ *
+ *   ?hl=ko   ?hl=ja   ?hl=zh-cn
+ *
+ * All three were cross-checked against each other and against the last English
+ * revision (2025-12-05 Internet Archive snapshot): 228 machine types, zero
+ * disagreements on any value. Note the URL above is the Korean page on purpose;
+ * dropping ?hl= returns the English page, which no longer has the data.
+ *
+ * These localized pages could be trimmed to match English at any time, so treat
+ * this map as the source of truth and re-check before assuming a refresh is
+ * possible. Machine types released after the last benchmark run (C4, A3, the
+ * newer A2 GPU shapes, shared-core E2) have no published score and are absent.
  */
 export const COREMARK_SCORES: Record<string, number> = {
   // N4 standard VMs — Emerald Rapids
@@ -419,6 +428,7 @@ export const COREMARK_SCORES: Record<string, number> = {
   'n4-highcpu-32': 707229,
   'n4-highcpu-48': 1058224,
   'n4-highcpu-64': 1351265,
+  'n4-highcpu-80': 1651766,
 
   // N4 highmem VMs — Emerald Rapids
   'n4-highmem-2':  44371,


### PR DESCRIPTION
Follow-up to #233. Corrects a claim I made there that turned out to be wrong.

## The English page isn't the only source

#233 documented this data as recovered from Internet Archive snapshots and **unrefreshable**, because Google removed the score tables from the [English page](https://cloud.google.com/compute/docs/coremark-scores-of-vm-instances) in early 2026.

That was wrong. **Three localized versions of the same page still serve the full tables:**

| Locale | Tables |
|---|---|
| [`?hl=ko`](https://cloud.google.com/compute/docs/coremark-scores-of-vm-instances?hl=ko), [`?hl=ja`](https://cloud.google.com/compute/docs/coremark-scores-of-vm-instances?hl=ja), [`?hl=zh-cn`](https://cloud.google.com/compute/docs/coremark-scores-of-vm-instances?hl=zh-cn) | ✅ 37 tables, 228 machine types |
| English (no `?hl=`) + de, fr, es, it, pt-br, ru, zh-tw, id, tr, vi, pl, nl, th | ❌ removed |

So there **is** a live source — it just isn't the English URL.

## Cross-validation

All three locales were checked against each other and against the last English revision (2025-12-05 archive snapshot):

- **228 machine types**
- **zero disagreements** on any value, across all three locales
- **zero values changed** versus what #233 already merged

That independently confirms the archived extraction in #233 was accurate — a useful result on its own, since that data was previously single-sourced.

## What changes

**One new score.** The live pages carry a machine type the archive predates:

```
n4-highcpu-80   1,651,766
```

`n4-highcpu-80` was already in `MACHINE_TYPES` but had no score. The value fits the N4 ladder cleanly (per-vCPU 20,647 against 21,114 for `n4-highcpu-64`). Coverage goes **219 → 220** of 262 instances.

**Corrected provenance.** The comment on `COREMARK_SCORES` and the `DATA_PIPELINE.md` section both said the data couldn't be refreshed from a public Google source. Both now point at the Korean URL, list which locales still carry the tables, and note that dropping `?hl=` gives you the English page without the data.

The caveat is kept: these localized pages could be trimmed to match English at any time, so `COREMARK_SCORES` stays the source of truth rather than something to re-scrape blindly.

## Verified from the merged pipeline output

Worth noting that #233's other fixes landed correctly — master's `pricing.json` (after two pipeline runs) shows both machine types added there now priced and scored:

```
g2-standard-32    446,322
n2d-highmem-80  1,484,925
```

## Testing

- `tsc -b` clean
- 122/122 tests pass
- `npm run build` succeeds
- `npm run validate` — truth table 43/43 passed
- `pricing.json` diff is exactly 1 line (the new score); no other field touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QaFsVD1VgGiDxnnS9YhZJy